### PR TITLE
docs(readme): add Contributor Terms section linking to T&C Section 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ This repo is the place to:
 - **Request a feature →** [New feature request](../../issues/new?template=feature_request.yml)
 - **Ask a question / start a discussion →** [Discussions tab](../../discussions)
 
+## Contributor terms — read before you post
+
+By filing an issue, opening a pull request, posting in discussions, or otherwise contributing to this repo or the EchoMTG community channels (Discord, public trackers, etc.), you agree to the **Community Contributions** terms in Section 13 of our Terms and Conditions:
+
+> **[Section 13 — Community Contributions](https://www.echomtg.com/legal/terms-and-conditions/#community-contributions)**
+
+The short version:
+
+- All contributions are **voluntary and unpaid**. There is no obligation to contribute, and no expectation of compensation, attribution, or future benefit.
+- By contributing you grant **ThoughtBomb Studios LLC dba EchoMTG** a perpetual, royalty-free license to use, modify, and incorporate your contribution into EchoMTG.
+- You **waive certain claims** against the Company arising from your contribution (compensation, attribution, IP infringement, trade-secret misappropriation, unjust enrichment, and equivalent claims in any jurisdiction). Read Section 13 in full for the exact scope.
+- **You must not be a minor.** Contributions in this repo and across the EchoMTG community channels are governed by U.S. and state child-labor and minimum-age-of-employment laws. By contributing you affirm that you are of **legal age in the state, province, or other jurisdiction in which you reside** and are not subject to any child-labor or minimum-age regulation that would restrict this kind of voluntary contribution. EchoMTG does not knowingly accept community contributions from minors.
+- **If you are a minor** — or believe you may be — please **do not contribute**. Instead, ask a parent or legal guardian to contact `teeg@echomtg.com` so the Company can determine how (or whether) to proceed. The Company reserves the right to remove or disregard any contributions made by a minor and to take any further action required for child-protection compliance.
+- The Company also retains the right to build, ship, and commercialize features that overlap with anything a contributor or third party builds on top of the EchoMTG API or data. See Clauses 3.6–3.10 of the [Terms and Conditions](https://www.echomtg.com/legal/terms-and-conditions/) for the full scope of API / data-use restrictions.
+
+If anything in Section 13 doesn't work for you, please don't contribute. Filing an issue or opening a PR is your assent to the terms above.
+
 ## Before you post
 
 - Search open and closed issues first — someone may have already raised it


### PR DESCRIPTION
## Summary

Companion PR to website#945. Adds a Contributor Terms section to the community repo README so anyone who lands here from a bug-report or feature-request link sees the contributor rules before they file. Cross-links to Section 13 of the EchoMTG Terms and Conditions.

## What's in the new section

Placed above the existing "Before you post" guidance:

- Hot-link to the website at the new `#community-contributions` anchor on the T&C page
- Plain-language summary of the four pillars of Section 13: voluntary / unpaid; perpetual license to ThoughtBomb Studios LLC dba EchoMTG; claim waiver; age-of-majority / not-a-minor
- Child-labor / minimum-age-of-employment compliance language
- Routing for minors: parent or legal guardian contact `teeg@echomtg.com`
- Cross-pointer to T&C 3.6-3.10 for API / data-use restrictions

## Test plan

- [ ] After merge, the README renders on the repo landing page with the new section above "Before you post"
- [ ] All three external links resolve once the T&C update on website (PR #945) is also on prod